### PR TITLE
Fix to the Issue after Qlik Sense Update and Few Enhancements

### DIFF
--- a/src/initialproperties.js
+++ b/src/initialproperties.js
@@ -1,16 +1,13 @@
-/*global define*/
-define( [], function () {
-    'use strict';
+define([], function() {
+    "use strict";
     return {
         qHyperCubeDef: {
             qDimensions: [],
             qMeasures: [],
-            qInitialDataFetch: [
-                {
-                    qWidth: 2,
-                    qHeight: 50
-                }
-            ]
+            qInitialDataFetch: [{
+                qWidth: 2,
+                qHeight: 50
+            }]
         }
-    };
-} );
+    }
+});

--- a/src/lib/css/style.css
+++ b/src/lib/css/style.css
@@ -29,22 +29,29 @@
       left: 0;
   }
   
+  .qv-collapsed-listbox{
+      background-color: rgb(255,255,255) !important;
+  }
+  
   .qs-side-bar .filter{
       margin-top: 5px;
       margin-bottom: 5px;
-      height:34px;
+      height: 34px;
   }
   
-  /*Very IMPORTANT*/
-  /*the below property is useful to restrict the background color of filters as white irrespective of the THEME of Qlik sense app.*/
-  .qv-collapsed-listbox{
-      background-color: rgb(255,255,255) !important; 
-  
-  }
   
   .qv-object .qv-inner-object{
-      height: 34px !important;
+      height: 100%;
   }
+  
+  .qsSideFilterTarget .qv-object-content-container{
+      background-color: #545352;
+  }
+  
+  .qsSideFilterTarget .ng-scope .qv-filterpane-expanded .qv-object-content-container{
+  	  background-color: rgb(255,255,255);
+  }
+  
   
   .heading{
   
@@ -53,6 +60,7 @@
       text-align: center;
       font-size: 18px;
       margin-top: 5px;
+	  font-weight: bold;
+	  text-decoration: underline;
   }
-  /* CSS */
   

--- a/src/lib/js/extensionUtils.js
+++ b/src/lib/js/extensionUtils.js
@@ -1,84 +1,19 @@
-define( [
-	'jquery',
-	'underscore'
-], function ( $, _ ) {
-	'use strict';
-
-	// Taken from http://www.briangrinstead.com/blog/console-log-helper-function
-	// Full version of `log` that:
-	//  * Prevents errors on console methods when no console present.
-	//  * Exposes a global 'log' function that preserves line numbering and formatting.
-	(function () {
-		var method;
-		var noop = function () { };
-		var methods = [
-			'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
-			'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
-			'markTimeline', 'profile', 'profileEnd', 'table', 'time', 'timeEnd',
-			'timeStamp', 'trace', 'warn'
-		];
-		var length = methods.length;
-		var console = (window.console = window.console || {});
-
-		while ( length-- ) {
-			method = methods[length];
-
-			// Only stub undefined methods.
-			if ( !console[method] ) {
-				console[method] = noop;
-			}
-		}
-
-		if ( Function.prototype.bind ) {
-			window.log = Function.prototype.bind.call( console.log, console );
-		}
-		else {
-			window.log = function () {
-				Function.prototype.apply.call( console.log, console, arguments );
-			};
-		}
-	})();
-
-	return {
-
-		/**
-		 * Add a style to the document's header.
-		 * @param cssContent {String} CSS content to be added to the header
-		 * @param id {String} If id is passed, addStyleToHeader will check if there has already been added a style with the given id, if yes, the css content will not be added to the header again
-		 */
-		addStyleToHeader: function ( cssContent, id ) {
-			if ( id && typeof id === 'string' ) {
-				if ( !$( '#' + id ).length ) {
-					$( "<style>" )
-						.attr( 'id', id )
-						.html( cssContent ).appendTo( "head" );
-				}
-			} else {
-				$( "<style>" ).html( cssContent ).appendTo( "head" );
-			}
-		},
-
-		/**
-		 * Add as style link to the document's header
-		 * @param {String} linkUrl Url to the CSS file
-		 * @param {String}  id If an id is passed, the function will check if this style link has already been added or not.
-		 * If yes, it will not be added again.
-		 */
-		addStyleLinkToHeader: function ( linkUrl, id ) {
-			if ( id && !_.isEmpty( id ) ) {
-				if ( !$( '#' + id ).length ) {
-					var $styleLink = $( document.createElement( 'link' ) );
-					$styleLink.attr( 'rel', 'stylesheet' );
-					$styleLink.attr( 'type', 'text/css' );
-					$styleLink.attr( 'href', linkUrl );
-					if ( id && !_.isEmpty( id ) ) {
-						$styleLink.attr( 'id', id );
-					}
-					$( 'head' ).append( $styleLink );
-				}
-			}
-		}
-
-	};
-
-} );
+define(["jquery", "underscore"], function(a, b) {
+    "use strict";
+    return function() {
+        for (var a, b = function() {}, c = ["assert", "clear", "count", "debug", "dir", "dirxml", "error", "exception", "group", "groupCollapsed", "groupEnd", "info", "log", "markTimeline", "profile", "profileEnd", "table", "time", "timeEnd", "timeStamp", "trace", "warn"], d = c.length, e = window.console = window.console || {}; d--;) a = c[d], e[a] || (e[a] = b);
+        window.log = Function.prototype.bind ? Function.prototype.bind.call(e.log, e) : function() {
+            Function.prototype.apply.call(e.log, e, arguments)
+        }
+    }(), {
+        addStyleToHeader: function(b, c) {
+            c && "string" == typeof c ? a("#" + c).length || a("<style>").attr("id", c).html(b).appendTo("head") : a("<style>").html(b).appendTo("head")
+        },
+        addStyleLinkToHeader: function(c, d) {
+            if (d && !b.isEmpty(d) && !a("#" + d).length) {
+                var e = a(document.createElement("link"));
+                e.attr("rel", "stylesheet"), e.attr("type", "text/css"), e.attr("href", c), d && !b.isEmpty(d) && e.attr("id", d), a("head").append(e)
+            }
+        }
+    }
+});

--- a/src/lib/partials/qvSlidePanel.js
+++ b/src/lib/partials/qvSlidePanel.js
@@ -1,114 +1,62 @@
-/* global define */
-define([
-  'qvangular',
-  'jquery',
-  'qlik'
-], function (qvangular,jquery,qlik) {
-  'use strict';
-
-  qvangular.directive("qvSlidePanel", function() {
-    return {
-      restrict: "A",
-      
-      scope: {
-        qvSlidePanel : '=',
-        qlikApp: '=',
-        qsSideFilters:'=',        
-        qsSideName:'='
-      },
-      
-      link: function(scope, elem, attrs) {
-
-        //se esiste rimuovo l'oggetto al caricamento della pagina
-        jquery( "div" ).remove(".qs-side-bar");
-
-        jquery( "body" ).append(
-            $('<div>', {
-                 'class': 'qs-side-bar bootstrap_inside'
-             }).append(
-
-                $('<div>', {
-                     'class': 'row'
-                 }).append(
-
-                    $('<div>', {
-                         'class': 'col-md-12',
-                         'margin-bottom': '20px'
-                     }).append(
-
-                        $('<div>', {
-                             'class': 'btn btn-block btn-success',
-                             'id': 'toggleSideMenu',
-                             'text': scope.qsSideName
-                         })
-
-                    )
-
-                )
-            )
-            .append(
-                $('<div>', {
-                     'class': 'row filter-container'
-                 })
-            ) 
-        );
-
-
-        jquery( "#toggleSideMenu" ).click(function() {
-          scope.qvSlidePanel=!scope.qvSlidePanel;
-          scope.$apply();
-        });
-       
-
-        scope.$watch('qvSlidePanel', function(newValue, oldValue, scope) {
-          if(newValue){
-            var sheetPosition = jquery( ".qvt-sheet.qv-panel-sheet").position();
-            jquery( ".qs-side-bar" ).addClass( "open" );
-          }
-          else{
-            jquery( ".qs-side-bar" ).removeClass( "open" );
-          }           
-        });
-
-var ok = true;
-        scope.$watch('qsSideFilters', function(newValue, oldValue, scope){ 
-               
-          var groups = newValue.map(function(group){
-            
-            ok = group.filterpane.reduce(function (oktmp,target) {
-              console.log(oktmp,target);
-              return oktmp && !isNaN(target.childFilters);
-            }, true);
-
-              console.log('ok',ok);
-            if(ok){
-              jquery( ".filter-container" ).empty();     
-              var filterpane =  group.filterpane.map(function(target){
-                  console.log('target',target);
-                  scope.qlikApp = qlik.currApp();
-                  if (target.childFilters == 1) {
-                    var fheight = 310; //the maximum height of filter that you want to make when there is rendering issue. Currently it is 310; i.e. 7*43. So it will occupy space of 7 filters. You can keep it as the (maximum filters in a single group)*43. In our case it was 7 filters.
-                  }
-                  else {
-                    var fheight = 43 * target.childFilters; //43 is the height of each filters.
-                  }
-
-                  //var fheight = ((34+5)*target.childFilters);
-                  console.log(fheight);
-                return '<div class = \"col-md-12 filter\" style = \"height: '+(fheight)+'px;\"><div  qsfilterid = "'+target.qInfo.qId+'" class=\"qsSideFilterTarget \" style = \"height: '+(fheight)+'px; width: 100%;border-radius: 2px;\"></div></div>'; });
-              return '<div class = \"col-md-12 \"><div class = "heading">'+group.heading+'</div></div>'+filterpane.join('');
+define(["qvangular", "jquery", "qlik"], function(a, b, c) {
+    "use strict";
+    a.directive("qvSlidePanel", function() {
+        return {
+            restrict: "A",
+            scope: {
+                qvSlidePanel: "=",
+                qlikApp: "=",
+                qsSideFilters: "=",
+                qsSideName: "="
+            },
+            link: function(a) {
+                b("div").remove(".qs-side-bar"), b("body").append($("<div>", {
+                    "class": "qs-side-bar bootstrap_inside"
+                }).append($("<div>", {
+                    "class": "row"
+                }).append($("<div>", {
+                    "class": "col-md-12",
+                    "margin-bottom": "20px"
+                }).append($("<div>", {
+                    "class": "btn btn-block btn-success",
+                    id: "toggleSideMenu",
+                    text: a.qsSideName
+                })))).append($("<div>", {
+                    "class": "row filter-container"
+                }))), b("#toggleSideMenu").click(function() {
+                    a.qvSlidePanel = !a.qvSlidePanel, a.$apply()
+                }), a.$watch("qvSlidePanel", function(a) {
+                    if (a) {
+                        {
+                            b(".qvt-sheet.qv-panel-sheet").position()
+                        }
+                        b(".qs-side-bar").addClass("open")
+                    } else b(".qs-side-bar").removeClass("open")
+                });
+                var d = !0;
+                a.$watch("qsSideFilters", function(a, e, f) {
+                    var g = a.map(function(a) {
+                        if (d = a.filterpane.reduce(function(a, b) {
+                                return a && !isNaN(b.childFilters)
+                            }, !0)) {
+                            b(".filter-container").empty();
+                            var e = a.filterpane.map(function(a) {
+                                f.qlikApp = c.currApp();
+                                if (a.childFilters == 1) {
+                                    var b = 440;    //max width it will occupy in case the filters are not loaded fully due to slow network.
+                                } else {
+                                    var b = 44 * a.childFilters; //in case the filters are loaded correctly then it will occupy this much space.
+                                }
+                                return '<div class = "col-md-12 filter" style = "height: ' + b + 'px;"><div  qsfilterid = "' + a.qInfo.qId + '" class="qsSideFilterTarget " style = "height: ' + b + 'px; width: 100%;border-radius: 2px;"></div></div>'
+                            });
+                            return '<div class = "col-md-12 "><div class = "heading">' + a.heading + "</div></div>" + e.join("")
+                        }
+                    });
+                    d && (b(".filter-container").append(g), b(".qsSideFilterTarget").each(function() {
+                        f.qlikApp.getObject($(this), $(this).attr("qsfilterid")).then(function() {})
+                    }))
+                }, !0)
             }
-          });
-          if(ok){
-            jquery( ".filter-container" ).append(groups)
-
-            jquery( ".qsSideFilterTarget" ).each(function(elem){
-              //console.log( $(this) );
-              scope.qlikApp.getObject( $(this), $(this).attr('qsfilterid') ).then(function (o) {});
-            })
-          }
-        },true)
-      }
-    }
-  });
+        }
+    })
 });

--- a/src/properties.js
+++ b/src/properties.js
@@ -1,149 +1,135 @@
-define( [], function () {
-	'use strict';
-
-	// ****************************************************************************************
-	// Other Settings
-	// ****************************************************************************************
-
-	var loadByTag = {
-		ref: "props.loadByTag",
-		label: "Load Masteritems by Defined Tags",
-		type: "boolean",
-		show: true,
-		defaultValue: true
-	};
-
-	var btnLabel = {
-		ref: "props.btnLabel",
-		label: "Menu Name",
-		type: "string",
-		show: true,
-		defaultValue:'QS Side Menu'
-	};
-
-	var group1Tag = {
-		ref: "props.groups.group1.tag",
-		label: "Associated Tag",
-		type: "string",
-		show: function(data){return data.props.loadByTag;},
-		defaultValue:'QSSideMenu'
-	};
-
-	var group2Tag = {
-		ref: "props.groups.group2.tag",
-		label: "Associated Tag",
-		type: "string",
-		show: function(data){return data.props.loadByTag;}
-	};
-
-	var group3Tag = {
-		ref: "props.groups.group3.tag",
-		label: "Associated Tag",
-		type: "string",
-		show: function(data){return data.props.loadByTag;}
-	};
-
-	var group4Tag = {
-		ref: "props.groups.group4.tag",
-		label: "Associated Tag",
-		type: "string",
-		show: function(data){return data.props.loadByTag;}
-	};
-
-
-
-	var group1Label = {
-		ref: "props.groups.group1.label",
-		label: "Menu Heading",
-		type: "string",
-		show: function(data){return data.props.loadByTag;},
-		defaultValue:'Filters'
-	};
-
-	var group2Label = {
-		ref: "props.groups.group2.label",
-		label: "Menu Heading",
-		type: "string",
-		show: function(data){return data.props.loadByTag;}
-	};
-
-	var group3Label = {
-		ref: "props.groups.group3.label",
-		label: "Menu Heading",
-		type: "string",
-		show: function(data){return data.props.loadByTag;}
-	};
-
-	var group4Label = {
-		ref: "props.groups.group4.label",
-		label: "Menu Heading",
-		type: "string",
-		show: function(data){return data.props.loadByTag;}
-	};
-
-	// ****************************************************************************************
-	// Property Panel Definition
-	// ****************************************************************************************
-
-	// Appearance Panel
-	var filterPanel = {
-		uses: "settings",
-		items: {
-			settings: {
-				type: "items",
-				label: "QS Side Menu",
-				items: {
-					loadByTag: loadByTag,
-					btnLabel: btnLabel
-				}
-			},
-
-			group1: {
-				type: "items",
-				label: "Group 1",
-				items: {
-					group1Tag:group1Tag,
-					group1Label:group1Label
-				}
-			},
-
-			group2: {
-				type: "items",
-				label: "Group 2",
-				items: {
-					group2Tag:group2Tag,
-					group2Label:group2Label
-				}
-			},
-
-			group3: {
-				type: "items",
-				label: "Group 3",
-				items: {
-					group3Tag:group3Tag,
-					group3Label:group3Label
-				}
-			},
-
-			group4: {
-				type: "items",
-				label: "Group 4",
-				items: {
-					group4Tag:group4Tag,
-					group4Label:group4Label
-				}
-			}
-		}
-	};
-
-	// Return values
-	return {
-		type: "items",
-		component: "accordion",
-		items: {
-			filterPanel: filterPanel
-
-		}
-	};
-
-} );
+define([], function() {
+    "use strict";
+    var a = {
+            ref: "props.loadByTag",
+            label: "Load Masteritems by Defined Tags",
+            type: "boolean",
+            show: !0,
+            defaultValue: !0
+        },
+        b = {
+            ref: "props.btnLabel",
+            label: "Menu Name",
+            type: "string",
+            show: !0,
+            defaultValue: "QS Side Menu"
+        },
+        c = {
+            ref: "props.groups.group1.tag",
+            label: "Associated Tag",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            },
+            defaultValue: "QSSideMenu"
+        },
+        d = {
+            ref: "props.groups.group2.tag",
+            label: "Associated Tag",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            }
+        },
+        e = {
+            ref: "props.groups.group3.tag",
+            label: "Associated Tag",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            }
+        },
+        f = {
+            ref: "props.groups.group4.tag",
+            label: "Associated Tag",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            }
+        },
+        g = {
+            ref: "props.groups.group1.label",
+            label: "Menu Heading",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            },
+            defaultValue: "Filters"
+        },
+        h = {
+            ref: "props.groups.group2.label",
+            label: "Menu Heading",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            }
+        },
+        i = {
+            ref: "props.groups.group3.label",
+            label: "Menu Heading",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            }
+        },
+        j = {
+            ref: "props.groups.group4.label",
+            label: "Menu Heading",
+            type: "string",
+            show: function(a) {
+                return a.props.loadByTag
+            }
+        },
+        k = {
+            uses: "settings",
+            items: {
+                settings: {
+                    type: "items",
+                    label: "QS Side Menu",
+                    items: {
+                        loadByTag: a,
+                        btnLabel: b
+                    }
+                },
+                group1: {
+                    type: "items",
+                    label: "Group 1",
+                    items: {
+                        group1Tag: c,
+                        group1Label: g
+                    }
+                },
+                group2: {
+                    type: "items",
+                    label: "Group 2",
+                    items: {
+                        group2Tag: d,
+                        group2Label: h
+                    }
+                },
+                group3: {
+                    type: "items",
+                    label: "Group 3",
+                    items: {
+                        group3Tag: e,
+                        group3Label: i
+                    }
+                },
+                group4: {
+                    type: "items",
+                    label: "Group 4",
+                    items: {
+                        group4Tag: f,
+                        group4Label: j
+                    }
+                }
+            }
+        };
+    return {
+        type: "items",
+        component: "accordion",
+        items: {
+            filterPanel: k
+        }
+    }
+});

--- a/src/qssidemenu.js
+++ b/src/qssidemenu.js
@@ -1,161 +1,50 @@
-define([
-        'qlik',
-        'jquery',
-        /*'underscore',*/
-        './properties',
-        './initialproperties',
-        './lib/js/extensionUtils',
-        'text!./lib/css/style.css',
-        'text!./lib/partials/template.html',
-        'text!./lib/css/scoped-bootstrap.css',
-        './lib/partials/qvSlidePanel'
-],
-function (qlik, $, /*_,*/ props, initProps, extensionUtils, cssContent, htmlTemplate, bootstrapCss) {
-    'use strict';
-
-    extensionUtils.addStyleToHeader(cssContent);
-    extensionUtils.addStyleToHeader(bootstrapCss);
-
-    console.log('Initializing - remove me');
-
-    return {
-
-        definition: props,
-
-        initialProperties: initProps,
-
-        snapshot: { canTakeSnapshot: true },
-
-        resize : function( /*$element, layout*/ ) {
-            //do nothing
+define(["qlik", "jquery", "./properties", "./initialproperties", "./lib/js/extensionUtils", "text!./lib/css/style.css", "text!./lib/partials/template.html", "text!./lib/css/scoped-bootstrap.css", "./lib/partials/qvSlidePanel"], function(a, b, c, d, e, f, g, h) {
+    "use strict";
+    return e.addStyleToHeader(f), e.addStyleToHeader(h), {
+        definition: c,
+        initialProperties: d,
+        snapshot: {
+            canTakeSnapshot: !0
         },
-
-        //clearSelectedValues : function($element) {
-        //
-        //},
-
-
-        // Angular Support (uncomment to use)
-        template: htmlTemplate,
-
-        // Angular Controller
-        controller: ['$scope', function ($scope) {
-            $scope.sideBarOpen= false;
-            $scope.filters = [];
-
-            $scope.qlikApp = qlik.currApp();
-            $scope.groups = [];
-           
-            
-
-            $scope.toggleMenu = function(){
-                $scope.sideBarOpen= !$scope.sideBarOpen;
-            };
-
-            function setUpView(){
-
-                if($scope.layout.props.loadByTag){
-                    $scope.groups = Object.keys($scope.layout.props.groups).reduce(function(groupTmp,currentGroup){
-                        if ($scope.layout.props.groups[currentGroup].tag.length>0){groupTmp.push($scope.layout.props.groups[currentGroup]);}
-                        return groupTmp;
-                    },[]);
-                }else{
-                    $scope.groups = [];
-                }
-
-                $scope.qlikApp.getList('masterobject').then(function(model) {
-                    console.log(model);
-                    console.log( $scope.groups);
-                    if($scope.groups.length==0){
-                        var filterIndex = 0;
-                        var filterpane = model.layout.qAppObjectList.qItems.reduce(function(filtersTmp,currentMO){
-                            if (currentMO.qData.visualization=="filterpane"){
-                                currentMO.childFilters=1;
-
-                                filtersTmp.push(currentMO);
-                                $scope.qlikApp.getObjectProperties(currentMO.qInfo.qId).then(function(model){
-                                    //console.log(model.layout.qChildList.qItems.length);
-                                    currentMO.childFilters=model.layout.qChildList.qItems.length;
-                                    $scope.filters[0].filterpane.childFilters=model.layout.qChildList.qItems.length;
-                                });
-                                
-                                return filtersTmp;
+        resize: function() {},
+        template: g,
+        controller: ["$scope", function(b) {
+            function c() {
+                b.groups = b.layout.props.loadByTag ? Object.keys(b.layout.props.groups).reduce(function(a, c) {
+                    return b.layout.props.groups[c].tag.length > 0 && a.push(b.layout.props.groups[c]), a
+                }, []) : [], b.qlikApp.getList("masterobject").then(function(a) {
+                    if (0 == b.groups.length) {
+                        var c = a.layout.qAppObjectList.qItems.reduce(function(a, c) {
+                            return "filterpane" == c.qData.visualization ? (c.childFilters = 1, a.push(c), b.qlikApp.getObjectProperties(c.qInfo.qId).then(function(a) {
+                                c.childFilters = a.layout.qChildList.qItems.length, b.filters[0].filterpane.childFilters = a.layout.qChildList.qItems.length
+                            }), a) : a
+                        }, []);
+                        b.filters = [{
+                            heading: "",
+                            filterpane: c
+                        }]
+                    } else b.filters = [], b.groups.forEach(function(c) {
+                        var d = a.layout.qAppObjectList.qItems.reduce(function(a, d) {
+                            if ("filterpane" == d.qData.visualization && d.qMeta.tags.indexOf(c.tag) > -1) {
+                                return d.childFilters = 1, b.qlikApp.getObjectProperties(d.qInfo.qId).then(function(a) {
+                                    b.filters[0].filterpane.childFilters = a.layout.qChildList.qItems.length, d.childFilters = a.layout.qChildList.qItems.length
+                                }), a.push(d), a
                             }
-                            else{
-                                return filtersTmp;
-                            }
-                            filterIndex++;
-                        },[]);
-
-                        $scope.filters = [
-                        {
-                            'heading':'',
-                            'filterpane':filterpane
-                        }
-                        ];
-
-                    }else{
-                        $scope.filters = [];
-                        $scope.groups.forEach(function(group) {
-
-                                var filterpane = model.layout.qAppObjectList.qItems.reduce(function(filtersTmp,currentMO){
-                                    if (currentMO.qData.visualization=="filterpane" && currentMO.qMeta.tags.indexOf(group.tag)>-1){
-                                        var filterIndex = 0;
-                                        currentMO.childFilters=1;
-                                        $scope.qlikApp.getObjectProperties(currentMO.qInfo.qId).then(function(model){
-                                            //console.log(model.layout.qChildList.qItems.length);
-                                            $scope.filters[0].filterpane.childFilters=model.layout.qChildList.qItems.length;
-                                            currentMO.childFilters=model.layout.qChildList.qItems.length;
-                                        });
-
-                                        filtersTmp.push(currentMO);
-                                        return filtersTmp;
-                                        filterIndex++;
-                                    }
-                                    else{
-                                        return filtersTmp;
-                                    }
-                                },[]);
-
-                                $scope.filters.push(
-                                {
-                                    'heading':group.label,
-                                    'filterpane':filterpane
-                                }
-                                );
-                        });
-                    }                    
-                    console.log($scope.filters);
-                });
+                            return a
+                        }, []);
+                        b.filters.push({
+                            heading: c.label,
+                            filterpane: d
+                        })
+                    })
+                })
             }
-
-            $scope.$watch('layout.props', function(newValue, oldValue, scope) {
-                setUpView();
-            }, true);
-          
-		
+            b.sideBarOpen = !1, b.filters = [], b.qlikApp = a.currApp(), b.groups = [], b.toggleMenu = function() {
+                b.sideBarOpen = !b.sideBarOpen
+            }, b.$watch("layout.props", function() {
+                c()
+            }, !0)
         }],
-
-
-        paint: function ( $element /*, layout*/ ) {
-
-            
-            
-            /*console.log('Basic Objects');
-            console.info('$element:');
-            console.log($element);
-            console.info('layout:');
-            console.log(layout);
-            console.groupEnd();
-            */
-
-            //$element.empty();
-            // var $helloWorld = $(document.createElement('div'));
-            // $helloWorld.addClass('hello-world');
-            // $helloWorld.html('Hello World from the extension "QS Side Menu"');
-            // $element.append($helloWorld);
-
-        }
-    };
-
+        paint: function() {}
+    }
 });

--- a/src/qssidemenu.qext
+++ b/src/qssidemenu.qext
@@ -1,9 +1,9 @@
 {
-	"name" : "QS Side Menu",
-	"description" : "a filters menu",
-	"icon" : "",
-	"type" : "visualization",
-	"version": "@@version",
-	"preview" : "qssidemenu.png",
-	"author": "Loris Lombardo"
+    "name": "QS Side Menu",
+    "description": "a filters menu",
+    "icon": "",
+    "type": "visualization",
+    "version": "0.0.1",
+    "preview": "qssidemenu.png",
+    "author": "Loris Lombardo"
 }

--- a/src/wbfolder.wbl
+++ b/src/wbfolder.wbl
@@ -1,0 +1,9 @@
+initialproperties.js;
+properties.js;
+qssidemenu.js;
+qssidemenu.qext;
+./lib/css/style.css;
+./lib/css/scoped-bootstrap.css;
+./lib/js/extensionUtils.js;
+./lib/partials/qvSlidePanel.js;
+./lib/partials/template.html;


### PR DESCRIPTION
**### Issues:**
**Issue 1:** Filters does not appear after the new QS Upgrade(Reported cases of malfunctioning in November and February Version). Only a button with 3 dots would appear.  Issue: https://github.com/LorisLombardo87/qs-side-menu/issues/12

**Probable Cause:**
Based on my understanding for some reason after the new QS version, when the QS engine tries to render the filters within the given area in extension, it somehow figures there isn't enough space available for rendering. Hence, it renders it in compressed form.

**Fix:**
One of the earlier CSS property seems to be responsible for this behaviour. 
Earlier:
<!--StartFragment-->  
                        .qv-object .qv-inner-object {      
                                     height: 34px !important;  
                         }
<!--EndFragment-->
Now:
<!--StartFragment-->  
                        .qv-object .qv-inner-object {
                                     height: 100%;
                        }
<!--EndFragment-->

The above change was making the filters appear correctly.
And to remove the white background colour between each filter within the group, I have added below piece of CSS property:
<!--StartFragment-->  
                        .qsSideFilterTarget .qv-object-content-container {
                                     background-color: #545352;
                        }
<!--EndFragment-->

But then the above property was not suitable when filters would be rendered in an expanded fashion, during a slow network when it would by default occupy space for 10 filters, irrespective of the number of filters in a group. So as the background colour is set to dark, the values of these expanded filters would not be visible. To fix this:
<!--StartFragment-->  
                          .qsSideFilterTarget .ng-scope .qv-filterpane-expanded .qv-object-content-container {
  	                             background-color: rgb(255,255,255);
                        }
<!--EndFragment-->

**Issue 2: When more numbers of filters were added in a single group, it does not render all and show expand all (3 dots) button at the bottom**

**Probable Cause:**
The below piece of logic was responsible for procuring the space so that each filter would fit within the area:

_In qvSlidePanel.js_
<!--StartFragment-->  
                                   var b = 43 * a.childFilters; 
<!--EndFragment-->

This was occupying (34 px(Size of each filter)+9(Bottom margin after each filters)) * number of filters within a group.

**Fix:**
Minor adjustment in the above logic:

_In qvSlidePanel.js_
<!--StartFragment-->  
                                   var b = 44 * a.childFilters; 
<!--EndFragment-->

**********************************************************************************************************************

**### Enhancement:**
**Enhancement 1: Filter Heading text bold and underlined**

Just slight modification in _Style.css_:
<!--StartFragment-->  
                                  .heading{
                                            color: white;
                                            width: 100%;
                                            text-align: center;
                                            font-size: 18px;
                                            margin-top: 5px;
	                                    font-weight: bold;                 //New Enhancement
	                                    text-decoration: underline;   //New Enhancement 
                                  }
<!--EndFragment-->


**Enhancement 2: Increased default space occupied during the slow network. Sufficient for 10 filters.**

_In qvSlidePanel:_
<!--StartFragment-->  
                                  var b = 440;
<!--EndFragment-->

